### PR TITLE
Feat : Add beast command to display challenge details

### DIFF
--- a/cmd/beast/challdetails.go
+++ b/cmd/beast/challdetails.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"github.com/sdslabs/beastv4/core/utils"
+	"github.com/spf13/cobra"
+)
+
+var challDetailsCmd = &cobra.Command{
+	Use:   "chall-details",
+	Short: "Lists all challenge details",
+	Long:  "Lists all challenge details | Flags available : --status , --tags. Status flag can take arguments : deployed / undeployed / queued. Tags flag can take multiple arguments seperated with ',' : challenges-with-tags (Ex : --tags=pwn,image,docker). This displays the list of challenges which have at least one tag provided by the user. User can also use both the flags for filtering challenges",
+
+	Run: func(cmd *cobra.Command, args []string) {
+		utils.ShowChallengesInfo(cmd, args)
+	},
+}

--- a/cmd/beast/challdetails.go
+++ b/cmd/beast/challdetails.go
@@ -8,9 +8,9 @@ import (
 var challDetailsCmd = &cobra.Command{
 	Use:   "chall-details",
 	Short: "Lists all challenge details",
-	Long:  "Lists all challenge details | Flags available : --status , --tags. Status flag can take arguments : deployed / undeployed / queued. Tags flag can take multiple arguments seperated with ',' : challenges-with-tags (Ex : --tags=pwn,image,docker). This displays the list of challenges which have at least one tag provided by the user. User can also use both the flags for filtering challenges",
+	Long:  "Lists all challenge details | Flags available : --status , --tags. Status flag can take arguments : deployed / undeployed / queued. Tags flag can take multiple arguments seperated with ',' : (Ex : --tags=pwn,image,docker). Details are shown for challenges that have specified status and one of the specified tags.",
 
 	Run: func(cmd *cobra.Command, args []string) {
-		utils.ShowChallengesInfo(cmd, args)
+		utils.ShowFilteredChallengesInfo(cmd, args)
 	},
 }

--- a/cmd/beast/commands.go
+++ b/cmd/beast/commands.go
@@ -95,7 +95,7 @@ func init() {
 	cmdRef.PersistentFlags().StringVarP(&RefDirectory, "reference-directory", "r", "", "Generate beast command reference files in reference directory")
 
 	challDetailsCmd.PersistentFlags().StringVarP(&Status, "status", "s", "all", "Filter by status : deployed / undeployed / queued")
-	challDetailsCmd.PersistentFlags().StringVarP(&Tags, "tags", "t", "all", "Filter by tagname : pwn / web / image / docker")
+	challDetailsCmd.PersistentFlags().StringVarP(&Tags, "tags", "t", "", "Filter by tagname : pwn / web / image / docker")
 
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)

--- a/cmd/beast/commands.go
+++ b/cmd/beast/commands.go
@@ -27,6 +27,8 @@ var (
 	LocalDirectory    string
 	DeleteEntry       bool
 	RefDirectory      string
+	Status            string
+	Tags              string
 )
 
 // Root command `beast` all commands are either a flag to this command
@@ -92,6 +94,9 @@ func init() {
 
 	cmdRef.PersistentFlags().StringVarP(&RefDirectory, "reference-directory", "r", "", "Generate beast command reference files in reference directory")
 
+	challDetailsCmd.PersistentFlags().StringVarP(&Status, "status", "s", "all", "Filter by status : deployed / undeployed / queued")
+	challDetailsCmd.PersistentFlags().StringVarP(&Tags, "tags", "t", "all", "Filter by tagname : pwn / web / image / docker")
+
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(runCmd)
@@ -104,4 +109,5 @@ func init() {
 	rootCmd.AddCommand(disableUserSSH)
 	rootCmd.AddCommand(cmdRef)
 	rootCmd.AddCommand(generateTemplateCmd)
+	rootCmd.AddCommand(challDetailsCmd)
 }

--- a/core/database/challenges.go
+++ b/core/database/challenges.go
@@ -94,7 +94,7 @@ func QueryAllChallenges() ([]Challenge, error) {
 	DBMux.Lock()
 	defer DBMux.Unlock()
 
-	tx := Db.Preload("Ports").Find(&challenges)
+	tx := Db.Preload("Ports").Preload("Tags").Find(&challenges)
 
 	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
 		return nil, nil

--- a/core/utils/show.go
+++ b/core/utils/show.go
@@ -10,6 +10,7 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/sdslabs/beastv4/core/database"
 	"github.com/sdslabs/beastv4/utils"
+	"github.com/spf13/cobra"
 )
 
 const maxShowLen int = 20
@@ -133,4 +134,109 @@ func PrintTableHeader(w *tabwriter.Writer) {
 	fmt.Fprintln(w, "Name\tContainerId\tImageId\tStatus\tPorts")
 	w.Flush()
 	fmt.Println(line)
+}
+
+// ShowChallengesInfo logs information about all the challenges present in the database
+func ShowChallengesInfo(cmd *cobra.Command, args []string) error {
+	challenges, err := database.QueryAllChallenges()
+	if err != nil {
+		return fmt.Errorf("Database query error : %v", err)
+	}
+	var filteredChallenges []database.Challenge
+	if len(challenges) > 0 {
+		status, _ := cmd.Flags().GetString("status")
+		status = strings.ToLower(status)
+		tags, _ := cmd.Flags().GetString("tags")
+		tags = strings.ToLower(tags)
+		tagArray := strings.Split(tags, ",")
+
+		for _, challenge := range challenges {
+			var includeChallenge bool
+			if status == "all" && tags == "all" {
+				includeChallenge = true
+			} else if status == "all" {
+				if tagsIntersection(tagArray, &challenge) {
+					includeChallenge = true
+				}
+			} else if tags == "all" {
+				if status == strings.ToLower(challenge.Status) {
+					includeChallenge = true
+				}
+			} else if status == strings.ToLower(challenge.Status) && tagsIntersection(tagArray, &challenge) {
+				includeChallenge = true
+			}
+
+			if includeChallenge {
+				filteredChallenges = append(filteredChallenges, challenge)
+			}
+		}
+	} else {
+		fmt.Errorf("No challenges present in the database.")
+		return nil
+	}
+
+	if len(filteredChallenges) > 0 {
+		header := []string{"Name", "Type", "Container ID", "Image ID", "Status", "Tagname", "healthcheck", "Ports"}
+		border := utils.CreateBorder(true, false, true, false)
+		tableConfigs := utils.CreateTableConfigs(border, header, "|")
+		data := challengesData(filteredChallenges)
+		utils.LogTable(tableConfigs, data)
+	} else {
+		fmt.Errorf("No challenges found for the provided filters.")
+	}
+
+	return nil
+}
+
+// tagsIntersection returns true if there exists an intersection between tags passed
+// by the user and tags of the challenge, else returns false
+func tagsIntersection(tagsInput []string, challenge *database.Challenge) bool {
+	for _, tagIn := range tagsInput {
+		for _, tag := range challenge.Tags {
+			if strings.ToLower(tagIn) == strings.ToLower(tag.TagName) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// concatenateAllPorts returns a string of all the ports of the queried challenge
+func concatenateAllPorts(ports []database.Port) string {
+	var portNumber string
+	for _, port := range ports {
+		portNumber = portNumber + fmt.Sprint(port.PortNo) + " "
+	}
+	return portNumber
+}
+
+// concatenateAllTags returns a string of all the tags of the queried challenge
+func concatenateAllTags(tags []*database.Tag) string {
+	var tagName string
+	for _, tag := range tags {
+		tagName = tagName + tag.TagName + " "
+	}
+	return tagName
+}
+
+// challengeData returns a 2D array of data of queried challenges
+func challengesData(challenges []database.Challenge) [][]string {
+	data := [][]string{}
+	for _, challenge := range challenges {
+		var tagName string = concatenateAllTags(challenge.Tags)
+		var portNumber string = concatenateAllPorts(challenge.Ports)
+		row := []string{
+			challenge.Name,
+			challenge.Type,
+			challenge.ContainerId[0:15],
+			challenge.ImageId[0:15],
+			challenge.Status,
+			tagName,
+			fmt.Sprintf("%d", challenge.HealthCheck),
+			portNumber,
+		}
+		data = append(data, row)
+	}
+	return data
 }

--- a/utils/log_table.go
+++ b/utils/log_table.go
@@ -1,0 +1,46 @@
+package utils
+
+import (
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+type TableConfigs struct {
+	Seperator   string
+	TableHeader []string
+	TableBorder tablewriter.Border
+}
+
+type TableBorder struct {
+	Seperator   string
+	TableHeader []string
+	TableBorder tablewriter.Border
+}
+
+// logTable logs table with given configs and data
+func LogTable(configs TableConfigs, data [][]string) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader(configs.TableHeader)
+	table.SetBorders(configs.TableBorder)
+	table.SetCenterSeparator(configs.Seperator)
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func CreateTableConfigs(border tablewriter.Border, header []string, seperator string) TableConfigs {
+	return TableConfigs{
+		TableBorder: border,
+		TableHeader: header,
+		Seperator:   seperator,
+	}
+}
+
+func CreateBorder(left bool, right bool, top bool, bottom bool) tablewriter.Border {
+	return tablewriter.Border{
+		Left:   left,
+		Right:  right,
+		Top:    top,
+		Bottom: bottom,
+	}
+}

--- a/utils/logtable.go
+++ b/utils/logtable.go
@@ -12,13 +12,7 @@ type TableConfigs struct {
 	TableBorder tablewriter.Border
 }
 
-type TableBorder struct {
-	Seperator   string
-	TableHeader []string
-	TableBorder tablewriter.Border
-}
-
-// logTable logs table with given configs and data
+// LogTable logs table with given configs and data
 func LogTable(configs TableConfigs, data [][]string) {
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader(configs.TableHeader)
@@ -28,6 +22,7 @@ func LogTable(configs TableConfigs, data [][]string) {
 	table.Render()
 }
 
+// CreateTableConfigs creates and returns an object of the type TableConfigs
 func CreateTableConfigs(border tablewriter.Border, header []string, seperator string) TableConfigs {
 	return TableConfigs{
 		TableBorder: border,
@@ -36,6 +31,7 @@ func CreateTableConfigs(border tablewriter.Border, header []string, seperator st
 	}
 }
 
+// CreateBorder creates and returns an object of the type tablewriter.Border
 func CreateBorder(left bool, right bool, top bool, bottom bool) tablewriter.Border {
 	return tablewriter.Border{
 		Left:   left,


### PR DESCRIPTION
### Command :
`beast chall-details` : Logs details about all the challenges available.

### Flags added : 

- `--status `

User can filter challenges according to challenge status : `deployed / undeployed / queued`
Ex : `--status=deployed`

- `--tags`

User can filter challenges according to tags assigned. Multiple tag filters can also be given as input.
Ex : `--tags=docker,image,web`

![image](https://user-images.githubusercontent.com/76244077/127026726-022a2998-a183-45d3-bfe1-0df14a76ac67.png)
![image](https://user-images.githubusercontent.com/76244077/127026919-dc301961-865f-4b0b-82c6-7b7f34dc0a09.png)

