### PR TITLE
Fix: Add ability to auto deploy challenges from remote

### DIFF
--- a/_examples/example.config.toml
+++ b/_examples/example.config.toml
@@ -22,6 +22,7 @@ available_sidecars = ["mysql"]
 jwt_secret = "beast"
 allowed_base_images = ["ubuntu:16.04", "php:7.1-cli"]
 authorized_keys_file = "/home/vsts/.beast/authorized_keys"
+remote_sync_period = "0h2m0s"
 
 [[remote]]
 ssh_key = "/home/vsts/.beast/secret.key"

--- a/api/main.go
+++ b/api/main.go
@@ -47,7 +47,7 @@ func runBeastApiBootsteps() error {
 // @in header
 // @name Authorization
 
-func RunBeastApiServer(port string, autoDeploy bool, healthProbe, periodicSync bool) {
+func RunBeastApiServer(port string, autoDeploy, healthProbe, periodicSync bool) {
 	log.Info("Bootstrapping Beast API server")
 
 	config.InitConfig()
@@ -89,8 +89,8 @@ func RunBeastApiServer(port string, autoDeploy bool, healthProbe, periodicSync b
 	BeastScheduler.Start()
 
 	if periodicSync {
-		log.Infof("Scheduling periodic remote sync for beast with period: %v", config.Cfg.RemoteSyncPeriod)
-		BeastScheduler.ScheduleEvery(config.Cfg.RemoteSyncPeriod, manager.SyncBeastRemote)
+		log.Infof("Scheduling periodic remote sync and auto update for beast with period: %v", config.Cfg.RemoteSyncPeriod)
+		BeastScheduler.ScheduleEvery(config.Cfg.RemoteSyncPeriod, manager.AutoUpdate)
 	}
 
 	if healthProbe {

--- a/api/main.go
+++ b/api/main.go
@@ -47,7 +47,7 @@ func runBeastApiBootsteps() error {
 // @in header
 // @name Authorization
 
-func RunBeastApiServer(port string, healthProbe, periodicSync bool) {
+func RunBeastApiServer(port string, autoDeploy bool, healthProbe, periodicSync bool) {
 	log.Info("Bootstrapping Beast API server")
 
 	config.InitConfig()
@@ -95,6 +95,10 @@ func RunBeastApiServer(port string, healthProbe, periodicSync bool) {
 
 	if healthProbe {
 		go manager.ChallengesHealthProber(config.Cfg.TickerFrequency)
+	}
+
+	if autoDeploy {
+		manager.InitialAutoDeploy()
 	}
 
 	router.Run(port)

--- a/cmd/beast/commands.go
+++ b/cmd/beast/commands.go
@@ -21,6 +21,7 @@ var (
 	PublicKeyPath     string
 	SkipAuthorization bool
 	AllChalls         bool
+	AutoDeploy        bool
 	PeriodicSync      bool
 	Tag               string
 	LocalDirectory    string
@@ -69,6 +70,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Print extra information in stdout1")
 
 	runCmd.PersistentFlags().StringVarP(&Port, "port", "p", "", "Port to run the beast server on.")
+	runCmd.PersistentFlags().BoolVarP(&AutoDeploy, "auto-deploy", "a", false, "Auto deploy challenges from remote.")
 	runCmd.PersistentFlags().BoolVarP(&HealthProbe, "health-probe", "k", false, "Run health check service for beast deployed challenges")
 	runCmd.PersistentFlags().BoolVarP(&PeriodicSync, "periodic-sync", "s", false, "Periodically sync remote with beast.")
 	runCmd.PersistentFlags().BoolVarP(&SkipAuthorization, "noauth", "n", false, "Skip Authorization")

--- a/cmd/beast/commands.go
+++ b/cmd/beast/commands.go
@@ -70,9 +70,9 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Print extra information in stdout1")
 
 	runCmd.PersistentFlags().StringVarP(&Port, "port", "p", "", "Port to run the beast server on.")
-	runCmd.PersistentFlags().BoolVarP(&AutoDeploy, "auto-deploy", "a", false, "Auto deploy challenges from remote.")
+	runCmd.PersistentFlags().BoolVarP(&AutoDeploy, "auto-deploy", "a", false, "Auto deploy all challenges from remote on server start.")
 	runCmd.PersistentFlags().BoolVarP(&HealthProbe, "health-probe", "k", false, "Run health check service for beast deployed challenges")
-	runCmd.PersistentFlags().BoolVarP(&PeriodicSync, "periodic-sync", "s", false, "Periodically sync remote with beast.")
+	runCmd.PersistentFlags().BoolVarP(&PeriodicSync, "periodic-sync", "s", false, "Periodically sync remote with beast and auto update challenges.")
 	runCmd.PersistentFlags().BoolVarP(&SkipAuthorization, "noauth", "n", false, "Skip Authorization")
 
 	getAuthCmd.PersistentFlags().StringVarP(&Username, "username", "u", "", "Username")

--- a/cmd/beast/run.go
+++ b/cmd/beast/run.go
@@ -20,6 +20,6 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		api.RunBeastApiServer(Port, HealthProbe, PeriodicSync)
+		api.RunBeastApiServer(Port, AutoDeploy, HealthProbe, PeriodicSync)
 	},
 }

--- a/core/manager/challenge.go
+++ b/core/manager/challenge.go
@@ -429,6 +429,19 @@ func HandleAll(action string, user string) []string {
 	return handleMultipleChallenges(challsNameList, action)
 }
 
+// Auto deploy challenges on server start
+// Assumes that the git remote has already been synced
+func InitialAutoDeploy() {
+	log.Infof("Starting to auto deploy all challenges")
+
+	challsNameList, err := GetAvailableChallenges()
+	if err != nil || len(challsNameList) == 0 {
+		log.Warnf("No challenge available")
+	}
+
+	handleMultipleChallenges(challsNameList, core.MANAGE_ACTION_DEPLOY)
+}
+
 // Unstage a challenge based on the challenge name.
 // This simply removes the staging directory for the challenge from the staging area.
 func unstageChallenge(challengeName string) error {

--- a/core/manager/challenge.go
+++ b/core/manager/challenge.go
@@ -429,17 +429,113 @@ func HandleAll(action string, user string) []string {
 	return handleMultipleChallenges(challsNameList, action)
 }
 
-// Auto deploy challenges on server start
+// InitialAutoDeploy deploys challenges on server start
 // Assumes that the git remote has already been synced
 func InitialAutoDeploy() {
 	log.Infof("Starting to auto deploy all challenges")
 
+	synced := IsAlreadySynced()
+	if !synced {
+		log.Errorf("Git remote not synced")
+		return
+	}
+
 	challsNameList, err := GetAvailableChallenges()
-	if err != nil || len(challsNameList) == 0 {
+	if err != nil {
+		log.Errorf("Error while getting available challenges: %s", err.Error())
+		return
+	}
+	if len(challsNameList) == 0 {
 		log.Warnf("No challenge available")
+		return
 	}
 
 	handleMultipleChallenges(challsNameList, core.MANAGE_ACTION_DEPLOY)
+}
+
+// AutoUpdate deploys/updates challenges (without an explicit request)
+// Rules:
+//   - If a new challenge is added to the remote repo then it is deployed
+//   - If an existing challenge is modified in the remote repo then it is redeployed
+//   - If an existing challenge is deleted in the remote repo then it is purged
+// Note:
+//   If an existing challenge was undeployed manually then it will
+//   remain undeployed even if it is modified in the remote remo, but
+//   it will be purged if it is deleted in the remote repo
+func AutoUpdate() {
+	log.Infof("Checking for updates in remote repository")
+
+	oldChalls, err := GetAvailableChallenges()
+	if err != nil {
+		log.Errorf("Error getting challenges present in local repo: %s", err.Error())
+		return
+	}
+	oldChallsSet := utils.SetFromArray(oldChalls)
+
+	modifiedChalls := SyncAndGetChangesFromRemote()
+	if len(modifiedChalls) > 0 {
+		log.Infof("Detected changes in challenge(s): %v", modifiedChalls)
+	} else {
+		log.Infof("No changes detected since last sync")
+		return
+	}
+
+	newChalls, err := GetAvailableChallenges()
+	if err != nil {
+		log.Warnf("Error getting challenges present in local repo: %s", err.Error())
+		return
+	}
+	newChallsSet := utils.SetFromArray(newChalls)
+
+	undeployedChalls, err := database.QueryChallengeEntriesMap(map[string]interface{}{
+		"Status": core.DEPLOY_STATUS["undeployed"],
+	})
+	if err != nil {
+		log.Warnf("Error getting undeployed challenges: %s", err.Error())
+		return
+	}
+	undeployedChallsSet := utils.EmptySet()
+	for _, undeployedChall := range undeployedChalls {
+		undeployedChallsSet.Add(undeployedChall.Name)
+	}
+
+	var (
+		challsToDeploy   []string
+		challsToRedeploy []string
+		challsToPurge    []string
+	)
+
+	for _, modifiedChall := range modifiedChalls {
+		presentInOldChalls := oldChallsSet.Contains(modifiedChall)
+		presentInNewChalls := newChallsSet.Contains(modifiedChall)
+		presentInUndeployedChalls := undeployedChallsSet.Contains(modifiedChall)
+
+		if presentInUndeployedChalls && presentInOldChalls {
+			log.Warnf("Changes detected in undeployed challenge %s, ignoring them", modifiedChall)
+			continue
+		}
+
+		if !presentInOldChalls && presentInNewChalls {
+			challsToDeploy = append(challsToDeploy, modifiedChall)
+		} else if presentInOldChalls && presentInNewChalls {
+			challsToRedeploy = append(challsToRedeploy, modifiedChall)
+		} else if presentInOldChalls && !presentInNewChalls {
+			challsToPurge = append(challsToPurge, modifiedChall)
+		}
+	}
+
+	if len(challsToDeploy) > 0 {
+		log.Infof("Deploying challenge(s): %v", challsToDeploy)
+		handleMultipleChallenges(challsToDeploy, core.MANAGE_ACTION_DEPLOY)
+	}
+	if len(challsToRedeploy) > 0 {
+		log.Infof("Redeploying challenge(s): %v", challsToRedeploy)
+		handleMultipleChallenges(challsToRedeploy, core.MANAGE_ACTION_REDEPLOY)
+	}
+	if len(challsToPurge) > 0 {
+		log.Infof("Purging challenge(s): %v", challsToPurge)
+		handleMultipleChallenges(challsToPurge, core.MANAGE_ACTION_PURGE)
+	}
 }
 
 // Unstage a challenge based on the challenge name.

--- a/core/manager/utils.go
+++ b/core/manager/utils.go
@@ -619,6 +619,24 @@ func GetAvailableChallenges() ([]string, error) {
 	return challsNameList, nil
 }
 
+// ExtractChallengeNamesFromFileNames extracts names of challenges from an array of filenames (git style file paths)
+func ExtractChallengeNamesFromFileNames(fileNames []string) []string {
+	var challengeNames []string
+	set := utils.EmptySet() // A set to help avoid duplicate entries
+	for _, fileName := range fileNames {
+		filePathArr := strings.Split(fileName, "/")
+		if len(filePathArr) > 2 && filePathArr[0] == core.BEAST_REMOTE_CHALLENGE_DIR {
+			challengeName := filePathArr[1]
+			if !set.Contains(challengeName) {
+				challengeNames = append(challengeNames, challengeName)
+				set.Add(challengeName)
+			}
+		} 
+	}
+	
+	return challengeNames
+}
+
 //UnTars challenge folder in a destination directory
 func UnTarChallengeFolder(tarContextPath, dstPath string) (string, error) {
 	baseFileName := filepath.Base(tarContextPath)
@@ -740,7 +758,7 @@ func UpdateChallenges() {
 			var config cfg.BeastChallengeConfig
 			_, err := toml.DecodeFile(configFile, &config)
 			if err != nil {
-				log.Errorf("Error while decoding challenge config file")
+				log.Errorf("Error while decoding challenge config file: %s", err.Error())
 				continue
 			}
 			challengeName := config.Challenge.Metadata.Name

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/crypto/ssh"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 	gitssh "gopkg.in/src-d/go-git.v4/plumbing/transport/ssh"
 )
 
@@ -32,6 +33,47 @@ func getSSHAuth(sshKeyFile string) (*gitssh.PublicKeys, error) {
 	}
 
 	return auth, nil
+}
+
+// IsAlreadyUpToDate checks if the local repo is already up to date with the remote repo
+func IsAlreadyUpToDate(gitDir string, sshKeyFile string, branch string, remoteName string) (bool, error) {
+	auth, err := getSSHAuth(sshKeyFile)
+	if err != nil {
+		return false, fmt.Errorf("Error while generating auth for git: %s", err)
+	}
+
+	repo, err := git.PlainOpen(gitDir)
+	if err != nil {
+		return false, fmt.Errorf("Error while opening the path: %s", err)
+	}
+
+	refName := plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", branch))
+	currRef, err := repo.Reference(refName, true)
+	if err != nil {
+		return false, fmt.Errorf("Error while getting reference from local repo: %s", err)
+	}
+	currHash := currRef.Hash()
+
+	remote, err := repo.Remote(remoteName)
+	if err != nil {
+		return false, fmt.Errorf("Error while getting remote for git directory: %s", err)
+	}
+
+	refs, err := remote.List(&git.ListOptions{
+		Auth: auth,
+	})
+	if err != nil {
+		return false, fmt.Errorf("Error while listing remote references: %s", err)
+	}
+
+	for _, ref := range refs {
+		if ref.Name() == refName {
+			upToDate := ref.Hash() == currHash
+			return upToDate, nil
+		}
+	}
+
+	return false, fmt.Errorf("Reference %s not found in the remote repo", refName)
 }
 
 // Pull the git directory specified by gitDir using the provided sshKeyFile secret
@@ -65,6 +107,75 @@ func Pull(gitDir string, sshKeyFile string, branch string, remote string) error 
 
 	log.Debugf("Git pull completed for %s", gitDir)
 	return nil
+}
+
+// getLatestCommit gets the latest commit (as pointed by the HEAD reference) from the repository
+func getLatestCommit(repo *git.Repository) (*object.Commit, error) {
+	headRef, err := repo.Head()
+	if err != nil {
+		return nil, fmt.Errorf("Error while getting HEAD reference of git repository")
+	}
+
+	latestCommit, err := repo.CommitObject(headRef.Hash())
+	if err != nil {
+		return nil, fmt.Errorf("Error while getting latest commit from git repository")
+	}
+
+	return latestCommit, nil
+}
+
+// PullAndGetChanges pulls changes from remote and returns an array of file names which were changed
+func PullAndGetChanges(gitDir string, sshkeyFile string, branch string, remote string) ([]string, error) {
+	auth, err := getSSHAuth(sshkeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("Error while generating auth for git : %s", err)
+	}
+
+	repo, err := git.PlainOpen(gitDir)
+	if err != nil {
+		return nil, fmt.Errorf("Error while opening the path : %s", err)
+	}
+
+	oldCommit, err := getLatestCommit(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	worktree, err := repo.Worktree()
+	if err != nil {
+		return nil, fmt.Errorf("Error while getting Worktree for git directory : %s", err)
+	}
+
+	refName := plumbing.ReferenceName(fmt.Sprintf("refs/heads/%s", branch))
+	err = worktree.Pull(&git.PullOptions{
+		RemoteName:    remote,
+		ReferenceName: refName,
+		SingleBranch:  true,
+		Auth:          auth,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("Error while pulling from remote branch %s : %s", branch, err)
+	}
+
+	log.Debugf("Git pull completed for %s", gitDir)
+
+	newCommit, err := getLatestCommit(repo)
+	if err != nil {
+		return nil, err
+	}
+
+	patch, err := oldCommit.Patch(newCommit)
+	if err != nil {
+		return nil, fmt.Errorf("Error while getting patch from old commit to new commit")
+	}
+
+	fileStats := patch.Stats()
+	var filesChanged []string
+	for _, fileStat := range fileStats {
+		filesChanged = append(filesChanged, fileStat.Name)
+	}
+
+	return filesChanged, nil
 }
 
 // CLone the git repository to the specified git directory with the

--- a/utils/set.go
+++ b/utils/set.go
@@ -1,0 +1,29 @@
+package utils
+
+var void struct{}
+
+type Set struct {
+	Map map[string]struct{}
+}
+
+func (s *Set) Add(element string) {
+	s.Map[element] = void
+}
+
+func (s *Set) Contains(element string) bool {
+	_, isPresent := s.Map[element]
+	return isPresent 
+}
+
+func EmptySet() *Set {
+	return &Set{make(map[string]struct{})}
+}
+
+func SetFromArray(arr []string) *Set {
+	set := EmptySet()
+	for _, element := range arr {
+		set.Add(element)
+	}
+
+	return set
+}


### PR DESCRIPTION
## Changes
- Added a new flag for the `beast run` command to auto deploy challenges from remote on server start
The flag: `-a, --auto-deploy`

- Modified the existing `-s, --periodic-sync` flag to auto update challenges in addition to just syncing them from remote
## Usage
-  `-a, --auto-deploy`: deploy all challenges from remote on server start
-  `-s, --periodic-sync`: constantly monitor the remote with the `remote_sync_period` defined in the `config.toml` file and look for any changes in the challenges. Then accordingly `deploy`, `redeploy` or `purge` the modified challenges.

Fixes #215 