### PR TITLE
Feat : Add flag to build image of challenge without using cache

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -47,7 +47,7 @@ func runBeastApiBootsteps() error {
 // @in header
 // @name Authorization
 
-func RunBeastApiServer(port string, autoDeploy, healthProbe, periodicSync bool) {
+func RunBeastApiServer(port string, autoDeploy, healthProbe, periodicSync bool, noCache bool) {
 	log.Info("Bootstrapping Beast API server")
 
 	config.InitConfig()
@@ -101,5 +101,8 @@ func RunBeastApiServer(port string, autoDeploy, healthProbe, periodicSync bool) 
 		manager.InitialAutoDeploy()
 	}
 
+	if noCache {
+		log.Infof("Starting Beast server in no cache mode")
+	}
 	router.Run(port)
 }

--- a/cmd/beast/challenge.go
+++ b/cmd/beast/challenge.go
@@ -24,6 +24,13 @@ var challengeCmd = &cobra.Command{
 		// Since action is already verfied to exist it does not make sense to check
 		// its existence here therefore we directly parse the action from the command.
 		action := args[0]
+		noCache, _ := cmd.Flags().GetBool("no-cache")
+		if noCache && action == core.MANAGE_ACTION_DEPLOY {
+			config.NoCache = noCache
+		} else if noCache {
+			log.Errorf("no-cache flag is available only for \"deploy\" action")
+			os.Exit(1)
+		}
 
 		if action == core.MANAGE_ACTION_SHOW {
 
@@ -78,7 +85,7 @@ var challengeCmd = &cobra.Command{
 				os.Exit(1)
 			}
 
-			manager.StartDeployPipeline(LocalDirectory, false, false)
+			manager.StartDeployPipeline(LocalDirectory, false, false, false)
 			return
 		}
 

--- a/cmd/beast/commands.go
+++ b/cmd/beast/commands.go
@@ -29,6 +29,7 @@ var (
 	RefDirectory      string
 	Status            string
 	Tags              string
+	NoCache           bool
 )
 
 // Root command `beast` all commands are either a flag to this command
@@ -49,6 +50,8 @@ var rootCmd = &cobra.Command{
 		} else {
 			config.SkipAuthorization = false
 		}
+				
+		config.NoCache = NoCache
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		cmd.Help()
@@ -76,6 +79,7 @@ func init() {
 	runCmd.PersistentFlags().BoolVarP(&HealthProbe, "health-probe", "k", false, "Run health check service for beast deployed challenges")
 	runCmd.PersistentFlags().BoolVarP(&PeriodicSync, "periodic-sync", "s", false, "Periodically sync remote with beast and auto update challenges.")
 	runCmd.PersistentFlags().BoolVarP(&SkipAuthorization, "noauth", "n", false, "Skip Authorization")
+	runCmd.PersistentFlags().BoolVarP(&NoCache, "no-cache", "c", false, "Build image of challenge without using cache")
 
 	getAuthCmd.PersistentFlags().StringVarP(&Username, "username", "u", "", "Username")
 	getAuthCmd.PersistentFlags().StringVarP(&Password, "password", "p", "", "Password")
@@ -91,6 +95,7 @@ func init() {
 	challengeCmd.PersistentFlags().StringVarP(&Tag, "tag", "t", "", "Performs action to the tag provided")
 	challengeCmd.PersistentFlags().StringVarP(&LocalDirectory, "local-directory", "l", "", "Deploys challenge from local directory")
 	challengeCmd.PersistentFlags().BoolVarP(&DeleteEntry, "delete-entry", "d", false, "Deletes db entry related to this challenge")
+	challengeCmd.PersistentFlags().BoolVarP(&NoCache, "no-cache", "c", false, "Build image of challenge without using cache")
 
 	cmdRef.PersistentFlags().StringVarP(&RefDirectory, "reference-directory", "r", "", "Generate beast command reference files in reference directory")
 

--- a/cmd/beast/run.go
+++ b/cmd/beast/run.go
@@ -20,6 +20,6 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		api.RunBeastApiServer(Port, AutoDeploy, HealthProbe, PeriodicSync)
+		api.RunBeastApiServer(Port, AutoDeploy, HealthProbe, PeriodicSync, NoCache)
 	},
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -349,6 +349,7 @@ func UpdateUsedPortList() {
 
 var Cfg *BeastConfig
 var SkipAuthorization bool
+var NoCache bool
 var USED_PORTS_LIST []uint32
 
 // InitConfig loads the config from the global config file and populate

--- a/pkg/cr/images.go
+++ b/pkg/cr/images.go
@@ -65,7 +65,7 @@ func SearchImageByFilter(filterMap map[string]string) ([]types.ImageSummary, err
 	return images, err
 }
 
-func BuildImageFromTarContext(challengeName, challengeTag, tarContextPath, dockerCtxFile string) (*bytes.Buffer, string, error) {
+func BuildImageFromTarContext(challengeName, challengeTag, tarContextPath, dockerCtxFile string, noCache bool) (*bytes.Buffer, string, error) {
 	builderContext, err := os.Open(tarContextPath)
 	if err != nil {
 		return nil, "", fmt.Errorf("Error while opening staged file :: %s", tarContextPath)
@@ -76,6 +76,7 @@ func BuildImageFromTarContext(challengeName, challengeTag, tarContextPath, docke
 		Tags:       []string{challengeTag},
 		Remove:     true,
 		Dockerfile: dockerCtxFile,
+		NoCache:    noCache,
 	}
 
 	dockerClient, err := client.NewEnvClient()


### PR DESCRIPTION
### CLI based NoCache

### Flag Added

- `beast challenge deploy [challenge] -c`

Rebuilds docker image of previously deployed challenge instead of using it from cache.

![image](https://user-images.githubusercontent.com/76244077/127735121-f0994c3a-1ecd-41f8-a464-c698d20b35aa.png)
![image](https://user-images.githubusercontent.com/76244077/127735244-9ff0b09f-a80f-4183-9d37-b0114384f1ad.png)


### API based NoCache

### Command

- Start the beast server with NoCache flag `-c` : `beast run -nvc`

Any deploy request made after using this flag (while starting the server) will be built without using cache

![image](https://user-images.githubusercontent.com/76244077/127553951-e733c4bf-d401-4336-b24a-2b108030084e.png)