### PR TITLE
add q flag to allow auto creation of authors

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -23,8 +23,8 @@ const (
 
 var BeastScheduler scheduler.Scheduler = scheduler.NewScheduler()
 
-func runBeastApiBootsteps() error {
-	manager.RunBeastBootsteps()
+func runBeastApiBootsteps(defaultauthorpassword string) error {
+	manager.RunBeastBootsteps(defaultauthorpassword)
 
 	return nil
 }
@@ -47,7 +47,7 @@ func runBeastApiBootsteps() error {
 // @in header
 // @name Authorization
 
-func RunBeastApiServer(port string, autoDeploy, healthProbe, periodicSync bool, noCache bool) {
+func RunBeastApiServer(port, defaultauthorpassword string, autoDeploy, healthProbe, periodicSync bool, noCache bool) {
 	log.Info("Bootstrapping Beast API server")
 
 	config.InitConfig()
@@ -63,7 +63,7 @@ func RunBeastApiServer(port string, autoDeploy, healthProbe, periodicSync bool, 
 
 	auth.Init(core.ITERATIONS, core.HASH_LENGTH, core.TIMEPERIOD, core.ISSUER, config.Cfg.JWTSecret, []string{core.USER_ROLES["author"]}, []string{core.USER_ROLES["admin"]}, []string{core.USER_ROLES["contestant"]})
 
-	runBeastApiBootsteps()
+	runBeastApiBootsteps(defaultauthorpassword)
 
 	// Initialize Gin router.
 	router := initGinRouter()

--- a/api/remote.go
+++ b/api/remote.go
@@ -20,7 +20,7 @@ import (
 // @Failure 500 {object} api.HTTPPlainResp
 // @Router /api/remote/sync/ [post]
 func syncBeastGitRemote(c *gin.Context) {
-	err := manager.SyncBeastRemote()
+	err := manager.SyncBeastRemote("")
 	if err != nil {
 		log.Errorf("Error while syncing beast remote....")
 		c.JSON(http.StatusInternalServerError, HTTPPlainResp{
@@ -45,7 +45,7 @@ func syncBeastGitRemote(c *gin.Context) {
 // @Failure 500 {object} api.HTTPPlainResp
 // @Router /api/remote/reset/ [post]
 func resetBeastGitRemote(c *gin.Context) {
-	err := manager.ResetBeastRemote()
+	err := manager.ResetBeastRemote("")
 	if err != nil {
 		log.Errorf("Error while resetting beast remote....")
 		c.JSON(http.StatusInternalServerError, HTTPPlainResp{

--- a/cmd/beast/commands.go
+++ b/cmd/beast/commands.go
@@ -10,26 +10,27 @@ import (
 )
 
 var (
-	Verbose           bool
-	HealthProbe       bool
-	Port              string
-	Name              string
-	Host              string
-	Username          string
-	Email             string
-	Password          string
-	PublicKeyPath     string
-	SkipAuthorization bool
-	AllChalls         bool
-	AutoDeploy        bool
-	PeriodicSync      bool
-	Tag               string
-	LocalDirectory    string
-	DeleteEntry       bool
-	RefDirectory      string
-	Status            string
-	Tags              string
-	NoCache           bool
+	Verbose               bool
+	HealthProbe           bool
+	Port                  string
+	DefaultAuthorPassword string
+	Name                  string
+	Host                  string
+	Username              string
+	Email                 string
+	Password              string
+	PublicKeyPath         string
+	SkipAuthorization     bool
+	AllChalls             bool
+	AutoDeploy            bool
+	PeriodicSync          bool
+	Tag                   string
+	LocalDirectory        string
+	DeleteEntry           bool
+	RefDirectory          string
+	Status                string
+	Tags                  string
+	NoCache               bool
 )
 
 // Root command `beast` all commands are either a flag to this command
@@ -75,6 +76,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "Print extra information in stdout1")
 
 	runCmd.PersistentFlags().StringVarP(&Port, "port", "p", "", "Port to run the beast server on.")
+	runCmd.PersistentFlags().StringVarP(&DefaultAuthorPassword, "defaultauthorpassword", "q", "", "Default password for creating author, users are not created if value is empty string")
 	runCmd.PersistentFlags().BoolVarP(&AutoDeploy, "auto-deploy", "a", false, "Auto deploy all challenges from remote on server start.")
 	runCmd.PersistentFlags().BoolVarP(&HealthProbe, "health-probe", "k", false, "Run health check service for beast deployed challenges")
 	runCmd.PersistentFlags().BoolVarP(&PeriodicSync, "periodic-sync", "s", false, "Periodically sync remote with beast and auto update challenges.")

--- a/cmd/beast/run.go
+++ b/cmd/beast/run.go
@@ -20,6 +20,6 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		api.RunBeastApiServer(Port, AutoDeploy, HealthProbe, PeriodicSync, NoCache)
+		api.RunBeastApiServer(Port, DefaultAuthorPassword, AutoDeploy, HealthProbe, PeriodicSync, NoCache)
 	},
 }

--- a/core/manager/challenge.go
+++ b/core/manager/challenge.go
@@ -394,7 +394,7 @@ func HandleAll(action string, user string) []string {
 	log.Infof("Got request to %s ALL CHALLENGES", action)
 
 	if action == core.MANAGE_ACTION_DEPLOY {
-		err := SyncBeastRemote()
+		err := SyncBeastRemote("")
 		if err != nil {
 			// A hack for go-git which returns error when the git repo
 			// is up to date. This ignores this error.
@@ -494,7 +494,7 @@ func AutoUpdate() {
 	}
 	oldChallsSet := utils.SetFromArray(oldChalls)
 
-	modifiedChalls := SyncAndGetChangesFromRemote()
+	modifiedChalls := SyncAndGetChangesFromRemote("")
 	if len(modifiedChalls) > 0 {
 		log.Infof("Detected changes in challenge(s): %v", modifiedChalls)
 	} else {

--- a/core/manager/pipeline.go
+++ b/core/manager/pipeline.go
@@ -321,7 +321,7 @@ func bootstrapDeployPipeline(challengeDir string, skipStage bool, skipCommit boo
 	}
 
 	// Using the challenge dir we got, update the database entries for the challenge.
-	err = UpdateOrCreateChallengeDbEntry(&challenge, config)
+	err = UpdateOrCreateChallengeDbEntry(&challenge, config, "")
 	if err != nil {
 		log.Errorf("An error occured while creating db entry for challenge :: %s", challengeName)
 		log.Errorf("Db error : %s", err)

--- a/core/manager/sync.go
+++ b/core/manager/sync.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Sync the beast remote directory with the actual git repository.
-func SyncBeastRemote() error {
+func SyncBeastRemote(defaultauthorpassword string) error {
 	log.Info("Syncing local challenge repository with remote.")
 	beastRemoteDir := filepath.Join(core.BEAST_GLOBAL_DIR, core.BEAST_REMOTES_DIR)
 	dirGitRemote := make(map[string]string)
@@ -68,11 +68,11 @@ func SyncBeastRemote() error {
 	}
 	log.Info("Beast git base synced with remote")
 	go config.UpdateUsedPortList()
-	UpdateChallenges()
+	UpdateChallenges(defaultauthorpassword)
 	return fmt.Errorf(strings.Join(errStrings, "\n"))
 }
 
-func ResetBeastRemote() error {
+func ResetBeastRemote(defaultauthorpassword string) error {
 	var errStrings []string
 	log.Debugf("Cleaning existing remote directories")
 	for _, gitRemote := range config.Cfg.GitRemotes {
@@ -86,7 +86,7 @@ func ResetBeastRemote() error {
 			}
 		}
 	}
-	err := SyncBeastRemote()
+	err := SyncBeastRemote(defaultauthorpassword)
 	if err != nil {
 		log.Errorf("Error while syncing remote after clean : %s", err)
 	}
@@ -121,7 +121,7 @@ func IsAlreadySynced() bool {
 
 // SyncAndGetChangesFromRemote gets changes from remote since the last sync
 // Returns an array of names of challenges which were modified
-func SyncAndGetChangesFromRemote() []string {
+func SyncAndGetChangesFromRemote(defaultauthorpassword string) []string {
 	log.Info("Syncing local challenge repository with remote.")
 	var modifiedChallsNameList []string
 
@@ -188,14 +188,14 @@ func SyncAndGetChangesFromRemote() []string {
 	}
 	log.Info("Beast git base synced with remote")
 	go config.UpdateUsedPortList()
-	UpdateChallenges()
+	UpdateChallenges(defaultauthorpassword)
 
 	return modifiedChallsNameList
 }
 
-func RunBeastBootsteps() error {
+func RunBeastBootsteps(defaultauthorpassword string) error {
 	log.Info("Syncing beast git challenge dir with remote....")
 
-	_ = SyncBeastRemote()
+	_ = SyncBeastRemote(defaultauthorpassword)
 	return nil
 }

--- a/core/manager/utils.go
+++ b/core/manager/utils.go
@@ -445,9 +445,10 @@ func UpdateOrCreateChallengeDbEntry(challEntry *database.Challenge, config cfg.B
 			}
 			log.Infof("User with the given email does not exist : %v, creating this user", config.Author.Email)
 			newUser := database.User{
-				Name:      config.Author.Email,
+				Name:      config.Author.Name,
 				AuthModel: auth.CreateModel(config.Author.Email, defaultauthorpassword, core.USER_ROLES["author"]),
 				Email:     config.Author.Email,
+				SshKey:    config.Author.SSHKey,
 			}
 			err = database.CreateUserEntry(&newUser)
 			if err != nil {

--- a/core/manager/utils.go
+++ b/core/manager/utils.go
@@ -446,7 +446,7 @@ func UpdateOrCreateChallengeDbEntry(challEntry *database.Challenge, config cfg.B
 			log.Infof("User with the given email does not exist : %v, creating this user", config.Author.Email)
 			newUser := database.User{
 				Name:      config.Author.Email,
-				AuthModel: auth.CreateModel(config.Author.Email, defaultauthorpassword, core.USER_ROLES["contestant"]),
+				AuthModel: auth.CreateModel(config.Author.Email, defaultauthorpassword, core.USER_ROLES["author"]),
 				Email:     config.Author.Email,
 			}
 			err = database.CreateUserEntry(&newUser)

--- a/go.sum
+++ b/go.sum
@@ -132,7 +132,6 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.10 h1:CoZ3S2P7pvtP45xOtBw+/mDL2z0RKI576gSkzRRpdGg=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
@@ -184,8 +183,8 @@ github.com/stevvooe/resumable v0.0.0-20180830230917-22b14a53ba50/go.mod h1:1pdIZ
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/swaggo/gin-swagger v1.0.0 h1:k6Nn1jV49u+SNIWt7kejQS/iENZKZVMCNQrKOYatNF8=
 github.com/swaggo/gin-swagger v1.0.0/go.mod h1:Mt37wE46iUaTAOv+HSnHbJYssKGqbS25X19lNF4YpBo=

--- a/scripts/installenv.sh
+++ b/scripts/installenv.sh
@@ -54,6 +54,10 @@ function install_go() {
     /usr/local/go/bin/go version
 }
 
+function install_air(){
+  curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+}
+
 update
 upgrade
 
@@ -61,5 +65,6 @@ sudo apt-get install -y apt-transport-https libsqlite3-dev build-essential gcc g
 
 install_docker
 install_go
+install_air
 
 exit 0


### PR DESCRIPTION
Allow user to enable autocreation of authors while challenge deployment. To start the server, run the command as `beast run -q "somepassword"`. The author is created with the same name and ssh-key as mentioned in the `beast.toml` file
Also updates `scripts/installenv.sh` to install air