### PR TITLE
Changes search depth in accordance with the ideal directory structure

### DIFF
--- a/core/manager/utils.go
+++ b/core/manager/utils.go
@@ -793,7 +793,7 @@ func UpdateChallenges(defaultauthorpassword string) {
 		dirs := utils.GetAllDirectoriesNameTillDepth(challengeDir, depthChall)
 
 		uploadsDir := filepath.Join(core.BEAST_GLOBAL_DIR, core.BEAST_UPLOADS_DIR)
-		depthUploads := strings.Count(uploadsDir, string(os.PathSeparator)) + 2
+		depthUploads := strings.Count(uploadsDir, string(os.PathSeparator)) + 1
 		uploadedChalls := utils.GetAllDirectoriesNameTillDepth(uploadsDir, depthUploads)
 
 		dirs = append(dirs, uploadedChalls...)


### PR DESCRIPTION
I referred to the `.beast` directory structure mentioned [here](https://beast-docs-sdslabs.netlify.app/setup/) and changed the parameter for the search depth of `beast.toml` in the `.beast/uploads/` directory.