### PR TITLE
Update and add new routes to view submissions.

### DIFF
--- a/api/info.go
+++ b/api/info.go
@@ -1325,6 +1325,111 @@ func getChallengeAttempts(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+// Get submissions by user ID
+// @Summary Get submissions by user
+// @Description Returns all submissions for a specific user
+// @Tags info
+// @Accept json
+// @Produce json
+// @Param user_id path int true "User ID"
+// @Param Authorization header string true "Bearer"
+// @Success 200 {array} api.SubmissionResp
+// @Failure 400 {object} api.HTTPErrorResp
+// @Failure 404 {object} api.HTTPErrorResp
+// @Failure 500 {object} api.HTTPErrorResp
+// @Router /api/info/submissions/user/{user_id} [get]
+func getUserAttempts(c *gin.Context) {
+	username, err := coreUtils.GetUser(c.GetHeader("Authorization"))
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, HTTPErrorResp{
+			Error: "Unauthorized user",
+		})
+		return
+	}
+
+	user, err := database.QueryFirstUserEntry("username", username)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, HTTPErrorResp{
+			Error: "Unauthorized user",
+		})
+		return
+	}
+
+	isContestant := user.Role == core.USER_ROLES["contestant"]
+
+	userIDStr := c.Param("user_id")
+	userID, err := strconv.ParseUint(userIDStr, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, HTTPErrorResp{
+			Error: "Invalid user_id",
+		})
+		return
+	}
+
+	submissionUser, err := database.QueryUserById(uint(userID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, HTTPErrorResp{
+			Error: "User not found",
+		})
+		return
+	}
+
+	if submissionUser.Role != core.USER_ROLES["contestant"] {
+		c.JSON(http.StatusBadRequest, HTTPErrorResp{
+			Error: "Can only view submissions for contestants",
+		})
+		return
+	}
+
+	attempts, err := database.QueryUserAttempts(uint(userID))
+	if err != nil {
+		log.Errorf("DATABASE ERROR while fetching user attempts: %s", err.Error())
+		c.JSON(http.StatusInternalServerError, HTTPPlainResp{
+			Message: "DATABASE ERROR while processing the request.",
+		})
+		return
+	}
+
+	resp := make([]SubmissionResp, 0, len(attempts))
+
+	for _, attempt := range attempts {
+		if isContestant && !attempt.Correct {
+			continue
+		}
+
+		challenge, err := database.QueryChallengeEntries("id", strconv.Itoa(int(attempt.ChallengeID)))
+		if err != nil {
+			log.Errorf("DATABASE ERROR while fetching challenge details: %s", err.Error())
+			continue
+		}
+		if len(challenge) == 0 {
+			continue
+		}
+
+		challengeTags := make([]string, len(challenge[0].Tags))
+		for index, tag := range challenge[0].Tags {
+			challengeTags[index] = tag.TagName
+		}
+
+		submissionResp := SubmissionResp{
+			UserId:    submissionUser.ID,
+			Username:  submissionUser.Username,
+			ChallId:   challenge[0].ID,
+			ChallName: challenge[0].Name,
+			SolvedAt:  attempt.SolvedAt,
+			Success:   attempt.Correct,
+		}
+
+		if !isContestant {
+			submissionResp.Flag = attempt.Flag
+		}
+
+		resp = append(resp, submissionResp)
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
 func getLeaderboardGraphHandler(c *gin.Context) {
 	var topUsers []uint
 	// TODO: Add a check for leaderboard stale to prevent stale graphs

--- a/api/info.go
+++ b/api/info.go
@@ -1245,6 +1245,24 @@ func unfreezeLeaderboardHandler(c *gin.Context) {
 // @Failure 500 {object} api.HTTPErrorResp
 // @Router /api/challenges/{challenge_id}/attempts [get]
 func getChallengeAttempts(c *gin.Context) {
+	username, err := coreUtils.GetUser(c.GetHeader("Authorization"))
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, HTTPErrorResp{
+			Error: "Unauthorized user",
+		})
+		return
+	}
+
+	queryingUser, err := database.QueryFirstUserEntry("username", username)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, HTTPErrorResp{
+			Error: "Unauthorized user",
+		})
+		return
+	}
+
+	isContestant := queryingUser.Role == core.USER_ROLES["contestant"]
+
 	challengeIDStr := c.Param("challenge_id")
 	challengeID, err := strconv.ParseUint(challengeIDStr, 10, 64)
 	if err != nil {
@@ -1285,15 +1303,24 @@ func getChallengeAttempts(c *gin.Context) {
 
 	resp := make([]SubmissionResp, 0, len(attempts))
 	for _, attempt := range attempts {
-		resp = append(resp, SubmissionResp{
+		if isContestant && !attempt.Correct {
+			continue
+		}
+
+		submissionResp := SubmissionResp{
 			UserId:    attempt.UserId,
 			Username:  attempt.Username,
 			ChallId:   challenge[0].ID,
 			ChallName: challenge[0].Name,
-			Flag:      attempt.Flag,
 			SolvedAt:  attempt.SolvedAt,
 			Success:   attempt.Correct,
-		})
+		}
+
+		if !isContestant {
+			submissionResp.Flag = attempt.Flag
+		}
+
+		resp = append(resp, submissionResp)
 	}
 	c.JSON(http.StatusOK, resp)
 }

--- a/api/info.go
+++ b/api/info.go
@@ -1254,6 +1254,26 @@ func getChallengeAttempts(c *gin.Context) {
 		return
 	}
 
+	challenge, err := database.QueryChallengeEntries("id", challengeIDStr)
+	if err != nil {
+		log.Errorf("DATABASE ERROR while fetching challenge details: %s", err.Error())
+		c.JSON(http.StatusInternalServerError, HTTPPlainResp{
+			Message: "DATABASE ERROR while processing the request.",
+		})
+		return
+	}
+	if len(challenge) == 0 {
+		c.JSON(http.StatusNotFound, HTTPPlainResp{
+			Message: "Challenge not found",
+		})
+		return
+	}
+
+	challengeTags := make([]string, len(challenge[0].Tags))
+	for index, tag := range challenge[0].Tags {
+		challengeTags[index] = tag.TagName
+	}
+
 	attempts, err := database.QueryChallAttempts(challengeID)
 	if err != nil {
 		log.Errorf("DATABASE ERROR while fetching challenge attempts: %s", err.Error())
@@ -1262,14 +1282,17 @@ func getChallengeAttempts(c *gin.Context) {
 		})
 		return
 	}
-	resp := make([]UserSolveResp, 0, len(attempts))
+
+	resp := make([]SubmissionResp, 0, len(attempts))
 	for _, attempt := range attempts {
-		resp = append(resp, UserSolveResp{
-			Id:       attempt.Id,
-			Username: attempt.Username,
-			SolvedAt: attempt.SolvedAt,
-			Flag:     attempt.Flag,
-			Correct:  attempt.Correct,
+		resp = append(resp, SubmissionResp{
+			UserId:    attempt.UserId,
+			Username:  attempt.Username,
+			ChallId:   challenge[0].ID,
+			ChallName: challenge[0].Name,
+			Flag:      attempt.Flag,
+			SolvedAt:  attempt.SolvedAt,
+			Success:   attempt.Correct,
 		})
 	}
 	c.JSON(http.StatusOK, resp)

--- a/api/info.go
+++ b/api/info.go
@@ -770,6 +770,7 @@ func submissionsHandler(c *gin.Context) {
 				Flag:      submission.Flag,
 				SolvedAt:  submission.CreatedAt,
 				Success:   submission.Solved,
+				Cheating:  submission.Cheating,
 			}
 
 			submissionsResp = append(submissionsResp, singleSubmissionResp)
@@ -1303,7 +1304,7 @@ func getChallengeAttempts(c *gin.Context) {
 
 	resp := make([]SubmissionResp, 0, len(attempts))
 	for _, attempt := range attempts {
-		if isContestant && !attempt.Correct {
+		if isContestant && (!attempt.Correct || attempt.Cheating) {
 			continue
 		}
 
@@ -1318,6 +1319,7 @@ func getChallengeAttempts(c *gin.Context) {
 
 		if !isContestant {
 			submissionResp.Flag = attempt.Flag
+			submissionResp.Cheating = attempt.Cheating
 		}
 
 		resp = append(resp, submissionResp)
@@ -1393,7 +1395,7 @@ func getUserAttempts(c *gin.Context) {
 	resp := make([]SubmissionResp, 0, len(attempts))
 
 	for _, attempt := range attempts {
-		if isContestant && !attempt.Correct {
+		if isContestant && (!attempt.Correct || attempt.Cheating) {
 			continue
 		}
 
@@ -1422,6 +1424,7 @@ func getUserAttempts(c *gin.Context) {
 
 		if !isContestant {
 			submissionResp.Flag = attempt.Flag
+			submissionResp.Cheating = attempt.Cheating
 		}
 
 		resp = append(resp, submissionResp)

--- a/api/info.go
+++ b/api/info.go
@@ -727,7 +727,6 @@ func getAllUsersInfoHandler(c *gin.Context) {
 // @Failure 500 {object} api.HTTPErrorResp
 // @Router /api/info/submissions [get]
 func submissionsHandler(c *gin.Context) {
-
 	submissions, err := database.QueryAllSubmissions()
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, HTTPErrorResp{
@@ -768,12 +767,11 @@ func submissionsHandler(c *gin.Context) {
 				Username:  user.Username,
 				ChallId:   challenge[0].ID,
 				ChallName: challenge[0].Name,
-				Category:  challenge[0].Type,
-				Tags:      challengeTags,
-				Points:    challenge[0].Points,
-				SolvedAt:  submission.CreatedAt,
 				Flag:      submission.Flag,
+				SolvedAt:  submission.CreatedAt,
+				Success:   submission.Solved,
 			}
+
 			submissionsResp = append(submissionsResp, singleSubmissionResp)
 		}
 	}

--- a/api/info.go
+++ b/api/info.go
@@ -727,7 +727,21 @@ func getAllUsersInfoHandler(c *gin.Context) {
 // @Failure 500 {object} api.HTTPErrorResp
 // @Router /api/admin/submissions [get]
 func submissionsHandler(c *gin.Context) {
-	submissions, err := database.QueryAllSubmissions()
+	pageStr := c.Query("page")
+	if pageStr == "" {
+		pageStr = "1"
+	}
+	page, err := strconv.Atoi(pageStr)
+	if err != nil || page < 1 {
+		c.JSON(http.StatusBadRequest, HTTPErrorResp{
+			Error: "Invalid page number",
+		})
+		return
+	}
+
+	offset := (page - 1) * core.SUBMISSIONS_PAGE_SIZE
+
+	submissions, err := database.QuerySubmissionsWithPagination(core.SUBMISSIONS_PAGE_SIZE, offset)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, HTTPErrorResp{
 			Error: "DATABASE ERROR while processing the request.",
@@ -745,36 +759,35 @@ func submissionsHandler(c *gin.Context) {
 			return
 		}
 
-		if user.Role == core.USER_ROLES["contestant"] {
-			challenge, err := database.QueryChallengeEntries("id", strconv.Itoa(int(submission.ChallengeID)))
-			if err != nil {
-				c.JSON(http.StatusInternalServerError, HTTPErrorResp{
-					Error: "DATABASE ERROR while fetching user details.",
-				})
-			}
-			if len(challenge) == 0 {
-				continue
-			}
-
-			challengeTags := make([]string, len(challenge[0].Tags))
-
-			for index, tags := range challenge[0].Tags {
-				challengeTags[index] = tags.TagName
-			}
-
-			singleSubmissionResp := SubmissionResp{
-				UserId:    user.ID,
-				Username:  user.Username,
-				ChallId:   challenge[0].ID,
-				ChallName: challenge[0].Name,
-				Flag:      submission.Flag,
-				SolvedAt:  submission.CreatedAt,
-				Success:   submission.Solved,
-				Cheating:  submission.Cheating,
-			}
-
-			submissionsResp = append(submissionsResp, singleSubmissionResp)
+		challenge, err := database.QueryChallengeEntries("id", strconv.Itoa(int(submission.ChallengeID)))
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, HTTPErrorResp{
+				Error: "DATABASE ERROR while fetching challenge details.",
+			})
+			return
 		}
+		if len(challenge) == 0 {
+			continue
+		}
+
+		challengeTags := make([]string, len(challenge[0].Tags))
+
+		for index, tags := range challenge[0].Tags {
+			challengeTags[index] = tags.TagName
+		}
+
+		singleSubmissionResp := SubmissionResp{
+			UserId:    user.ID,
+			Username:  user.Username,
+			ChallId:   challenge[0].ID,
+			ChallName: challenge[0].Name,
+			Flag:      submission.Flag,
+			SolvedAt:  submission.CreatedAt,
+			Success:   submission.Solved,
+			Cheating:  submission.Cheating,
+		}
+
+		submissionsResp = append(submissionsResp, singleSubmissionResp)
 	}
 
 	format := c.Query("format")

--- a/api/info.go
+++ b/api/info.go
@@ -725,7 +725,7 @@ func getAllUsersInfoHandler(c *gin.Context) {
 // @Param Authorization header string true "Bearer"
 // @Success 200 {object} api.SubmissionResp
 // @Failure 500 {object} api.HTTPErrorResp
-// @Router /api/info/submissions [get]
+// @Router /api/admin/submissions [get]
 func submissionsHandler(c *gin.Context) {
 	submissions, err := database.QueryAllSubmissions()
 	if err != nil {

--- a/api/response.go
+++ b/api/response.go
@@ -157,11 +157,9 @@ type SubmissionResp struct {
 	Username  string    `json:"username" example:"fristonio"`
 	ChallId   uint      `json:"chall_id" example:"3"`
 	ChallName string    `json:"name" example:"Web Challenge"`
-	Category  string    `json:"category" example:"web"`
-	Tags      []string  `json:"tags" example:"['pwn','misc']"`
-	Points    uint      `json:"points" example:"50"`
 	Flag      string    `json:"flag" example:"flag{@#$}"`
 	SolvedAt  time.Time `json:"solvedAt"`
+	Success   bool      `json:"success" example:"true"`
 }
 
 type FlagSubmitResp struct {

--- a/api/response.go
+++ b/api/response.go
@@ -160,6 +160,7 @@ type SubmissionResp struct {
 	Flag      string    `json:"flag" example:"flag{@#$}"`
 	SolvedAt  time.Time `json:"solvedAt"`
 	Success   bool      `json:"success" example:"true"`
+	Cheating  bool      `json:"cheating" example:"false"`
 }
 
 type FlagSubmitResp struct {

--- a/api/router.go
+++ b/api/router.go
@@ -90,6 +90,7 @@ func initGinRouter() *gin.Engine {
 			infoGroup.GET("/usercount", getUserCountHandler)
 			infoGroup.GET("/submissions", submissionsHandler)
 			infoGroup.GET("/submissions/challenge/:challenge_id", getChallengeAttempts)
+			infoGroup.GET("/submissions/user/:user_id", getUserAttempts)
 			infoGroup.GET("/tags", tagHandler)
 			infoGroup.GET("/hint/:hintID", hintHandler)
 			infoGroup.POST("/hint/:hintID", hintHandler)

--- a/api/router.go
+++ b/api/router.go
@@ -88,7 +88,6 @@ func initGinRouter() *gin.Engine {
 			infoGroup.GET("/leaderboard", getLeaderboardHandler)
 			infoGroup.GET("leaderboard-graph", getLeaderboardGraphHandler)
 			infoGroup.GET("/usercount", getUserCountHandler)
-			infoGroup.GET("/submissions", submissionsHandler)
 			infoGroup.GET("/submissions/challenge/:challenge_id", getChallengeAttempts)
 			infoGroup.GET("/submissions/user/:user_id", getUserAttempts)
 			infoGroup.GET("/tags", tagHandler)
@@ -132,6 +131,7 @@ func initGinRouter() *gin.Engine {
 			adminPanelGroup.GET("/leaderboard", adminLeaderboardHandler)
 			adminPanelGroup.POST("/freezeLeaderboard", freezeLeaderboardHandler)
 			adminPanelGroup.POST("/unfreezeLeaderboard", unfreezeLeaderboardHandler)
+			adminPanelGroup.GET("/submissions", submissionsHandler)
 		}
 	}
 

--- a/api/router.go
+++ b/api/router.go
@@ -89,6 +89,7 @@ func initGinRouter() *gin.Engine {
 			infoGroup.GET("leaderboard-graph", getLeaderboardGraphHandler)
 			infoGroup.GET("/usercount", getUserCountHandler)
 			infoGroup.GET("/submissions", submissionsHandler)
+			infoGroup.GET("/submissions/challenge/:challenge_id", getChallengeAttempts)
 			infoGroup.GET("/tags", tagHandler)
 			infoGroup.GET("/hint/:hintID", hintHandler)
 			infoGroup.POST("/hint/:hintID", hintHandler)
@@ -130,8 +131,6 @@ func initGinRouter() *gin.Engine {
 			adminPanelGroup.GET("/leaderboard", adminLeaderboardHandler)
 			adminPanelGroup.POST("/freezeLeaderboard", freezeLeaderboardHandler)
 			adminPanelGroup.POST("/unfreezeLeaderboard", unfreezeLeaderboardHandler)
-			adminPanelGroup.GET("/challenges/:challenge_id/attempts", getChallengeAttempts)
-
 		}
 	}
 

--- a/api/submit.go
+++ b/api/submit.go
@@ -176,6 +176,7 @@ func submitFlagHandler(c *gin.Context) {
 		}
 
 		// If the challenge is dynamic, then the flag is not stored in the database
+		var isCheating bool
 		if challenge.DynamicFlag {
 			whereMap := map[string]interface{}{
 				"Name": challenge.Name,
@@ -185,15 +186,6 @@ func submitFlagHandler(c *gin.Context) {
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, HTTPErrorResp{
 					Error: "DATABASE ERROR while processing the request.",
-				})
-				return
-			}
-
-			// flag not present in validFlags table
-			if len(validFlags) == 0 {
-				c.JSON(http.StatusOK, FlagSubmitResp{
-					Message: "Your flag is incorrect",
-					Success: false,
 				})
 				return
 			}
@@ -209,13 +201,42 @@ func submitFlagHandler(c *gin.Context) {
 				})
 				return
 			}
-			if len(submissions) > 0 {
+
+			flagInValidFlags := len(validFlags) > 0
+			flagInSubmissions := len(submissions) > 0
+
+			// Case 1: Flag not in validFlags (incorrect flag) - no cheating detection for wrong flags
+			if !flagInValidFlags {
+				UserChallengesEntry := database.UserChallenges{
+					CreatedAt:   time.Now(),
+					UserID:      user.ID,
+					ChallengeID: challenge.ID,
+					Solved:      false,
+					Flag:        flag,
+					Cheating:    false,
+				}
+				err = database.SaveFlagSubmission(&UserChallengesEntry)
+				if err != nil {
+					c.JSON(http.StatusInternalServerError, HTTPErrorResp{
+						Error: "DATABASE ERROR while processing the request.",
+					})
+					return
+				}
+				c.JSON(http.StatusOK, FlagSubmitResp{
+					Message: "Your flag is incorrect",
+					Success: false,
+				})
+				return
+			}
+
+			// Case 2: Flag in validFlags and in submissions, cheating with valid flag
+			if flagInValidFlags && flagInSubmissions {
 				if user.ID != submissions[0].UserID {
-					// notify the admin about cheating
 					subuser, _ := database.QueryUserById(submissions[0].UserID)
-					msg := "User " + subuser.Username + " has submitted the flag " + flag + " for challenge " + challenge.Name + " which has already been solved by another user " + user.Username
+					msg := "User " + user.Username + " has submitted the flag " + flag + " for challenge " + challenge.Name + " which has already been solved by user " + subuser.Username
 					go notify.SendNotification(notify.Warning, msg)
-					go coreUtils.LogCheating(msg)
+					isCheating = true
+					// Continue to end of function with Solved: true, Cheating: true
 				} else {
 					c.JSON(http.StatusOK, FlagSubmitResp{
 						Message: "You have already solved this challenge",
@@ -224,6 +245,9 @@ func submitFlagHandler(c *gin.Context) {
 					return
 				}
 			}
+
+			// Case 3: Flag in validFlags but not in submissions (solved without cheating) and saved at the end.
+
 		} else {
 			if challenge.Flag != flag {
 				UserChallengesEntry := database.UserChallenges{
@@ -294,6 +318,7 @@ func submitFlagHandler(c *gin.Context) {
 			ChallengeID: challenge.ID,
 			Solved:      true,
 			Flag:        flag,
+			Cheating:    isCheating,
 		}
 
 		err = database.SaveFlagSubmission(&UserChallengesEntry)

--- a/core/constants.go
+++ b/core/constants.go
@@ -203,9 +203,11 @@ var USER_STATUS = map[string]string{
 const (
 	LEADERBOARD_SIZE       = 25
 	LEADERBOARD_GRAPH_SIZE = 12
+	SUBMISSIONS_PAGE_SIZE = 10
 )
 
 var NOTIFICATION_SERVICES = []string{
 	"slack",
 	"discord",
 }
+

--- a/core/database/challenges.go
+++ b/core/database/challenges.go
@@ -73,6 +73,7 @@ type Challenge struct {
 }
 
 type UserChallenges struct {
+	ID        uint `gorm:"primaryKey"`
 	CreatedAt time.Time
 	User      User `gorm:"foreignKey:UserID"`
 	UserID    uint
@@ -86,6 +87,7 @@ type UserChallenges struct {
 
 type ChallengeAttempt struct {
 	Id       uint      `json:"id"`
+	UserId   uint      `json:"userId"`
 	Username string    `json:"username"`
 	SolvedAt time.Time `json:"solvedAt"`
 	Flag     string    `json:"flag"`
@@ -682,7 +684,7 @@ func QueryChallAttempts(chall_id uint64) ([]ChallengeAttempt, error) {
 	defer DBMux.Unlock()
 
 	err := Db.Table("user_challenges").
-		Select("user_challenges.id as id, users.username as username, user_challenges.created_at as solved_at, user_challenges.flag as flag, user_challenges.solved as correct").
+		Select("user_challenges.id as id, user_challenges.user_id as user_id, users.username as username, user_challenges.created_at as solved_at, user_challenges.flag as flag, user_challenges.solved as correct").
 		Joins("JOIN users ON users.id = user_challenges.user_id").
 		Where("user_challenges.challenge_id = ?", chall_id).
 		Order("user_challenges.created_at ASC").

--- a/core/database/challenges.go
+++ b/core/database/challenges.go
@@ -86,12 +86,13 @@ type UserChallenges struct {
 }
 
 type ChallengeAttempt struct {
-	Id       uint      `json:"id"`
-	UserId   uint      `json:"userId"`
-	Username string    `json:"username"`
-	SolvedAt time.Time `json:"solvedAt"`
-	Flag     string    `json:"flag"`
-	Correct  bool      `json:"correct"`
+	Id          uint      `json:"id"`
+	UserId      uint      `json:"userId"`
+	ChallengeID uint      `json:"challengeId"`
+	Username    string    `json:"username"`
+	SolvedAt    time.Time `json:"solvedAt"`
+	Flag        string    `json:"flag"`
+	Correct     bool      `json:"correct"`
 }
 type UserLeaderboardResp struct {
 	Id             uint         `json:"id" example:"5"`
@@ -687,6 +688,26 @@ func QueryChallAttempts(chall_id uint64) ([]ChallengeAttempt, error) {
 		Select("user_challenges.id as id, user_challenges.user_id as user_id, users.username as username, user_challenges.created_at as solved_at, user_challenges.flag as flag, user_challenges.solved as correct").
 		Joins("JOIN users ON users.id = user_challenges.user_id").
 		Where("user_challenges.challenge_id = ?", chall_id).
+		Order("user_challenges.created_at ASC").
+		Scan(&attempts).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return attempts, nil
+}
+
+// QueryUserAttempts queries all attempts for a given user ID
+func QueryUserAttempts(user_id uint) ([]ChallengeAttempt, error) {
+	var attempts []ChallengeAttempt
+
+	DBMux.Lock()
+	defer DBMux.Unlock()
+
+	err := Db.Table("user_challenges").
+		Select("user_challenges.id as id, user_challenges.user_id as user_id, user_challenges.challenge_id as challenge_id, user_challenges.created_at as solved_at, user_challenges.flag as flag, user_challenges.solved as correct, user_challenges.cheating as cheating").
+		Where("user_challenges.user_id = ?", user_id).
 		Order("user_challenges.created_at ASC").
 		Scan(&attempts).Error
 

--- a/core/database/challenges.go
+++ b/core/database/challenges.go
@@ -475,6 +475,28 @@ func QueryAllSubmissions() ([]UserChallenges, error) {
 	return userChallenges, tx.Error
 }
 
+func QuerySubmissionsWithPagination(limit, offset int) ([]UserChallenges, error) {
+	var userChallenges []UserChallenges
+
+	DBMux.Lock()
+	defer DBMux.Unlock()
+
+	tx := Db.Table("user_challenges").
+		Select("user_challenges.*").
+		Joins("JOIN users ON users.id = user_challenges.user_id").
+		Where("users.role = ?", "contestant").
+		Order("user_challenges.created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&userChallenges)
+
+	if errors.Is(tx.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+
+	return userChallenges, tx.Error
+}
+
 // QuerySubmissions queries all challenge where column matches
 func QuerySubmissions(whereMap map[string]interface{}) ([]UserChallenges, error) {
 	var userChallenges []UserChallenges

--- a/core/database/challenges.go
+++ b/core/database/challenges.go
@@ -83,6 +83,7 @@ type UserChallenges struct {
 	Tries       uint   `gorm:"not null;default:0"`
 	Solved      bool   `gorm:"not null;default:false;index"`
 	Flag        string `gorm:"type:text"`
+	Cheating    bool   `gorm:"not null;default:false"`
 }
 
 type ChallengeAttempt struct {
@@ -93,6 +94,7 @@ type ChallengeAttempt struct {
 	SolvedAt    time.Time `json:"solvedAt"`
 	Flag        string    `json:"flag"`
 	Correct     bool      `json:"correct"`
+	Cheating    bool      `json:"cheating"`
 }
 type UserLeaderboardResp struct {
 	Id             uint         `json:"id" example:"5"`
@@ -685,7 +687,7 @@ func QueryChallAttempts(chall_id uint64) ([]ChallengeAttempt, error) {
 	defer DBMux.Unlock()
 
 	err := Db.Table("user_challenges").
-		Select("user_challenges.id as id, user_challenges.user_id as user_id, users.username as username, user_challenges.created_at as solved_at, user_challenges.flag as flag, user_challenges.solved as correct").
+		Select("user_challenges.id as id, user_challenges.user_id as user_id, users.username as username, user_challenges.created_at as solved_at, user_challenges.flag as flag, user_challenges.solved as correct, user_challenges.cheating as cheating").
 		Joins("JOIN users ON users.id = user_challenges.user_id").
 		Where("user_challenges.challenge_id = ?", chall_id).
 		Order("user_challenges.created_at ASC").

--- a/core/database/challenges.go
+++ b/core/database/challenges.go
@@ -332,7 +332,6 @@ func UpdateUserChallengeTries(userID uint, challengeID uint) error {
 	}
 
 	updates := map[string]interface{}{
-		"created_at": time.Now(),
 		"tries":      userChallenges.Tries + 1,
 	}
 

--- a/core/utils/logs.go
+++ b/core/utils/logs.go
@@ -62,19 +62,6 @@ func GetLogs(challname string, live bool) (*cr.Log, error) {
 	return cr.GetContainerStdLogs(chall.ContainerId)
 }
 
-func LogCheating(msg string) error {
-	// log the cheating attempt in a file in cheat.log
-	file, err := os.OpenFile(filepath.Join(core.BEAST_GLOBAL_DIR, core.BEAST_CHEAT_LOG_FILE), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return fmt.Errorf("error while opening cheat log file : %s", err)
-	}
-	defer file.Close()
-
-	if _, err := file.WriteString(msg + "\n"); err != nil {
-		return fmt.Errorf("error while appending to cheat log file : %s", err)
-	}
-	return nil
-}
 
 func LogFlag(msg string, challName string) error {
 	// log the cheating attempt in a file in cheat.log


### PR DESCRIPTION

Addition of new routes and features:
-  `/api/info/submissions/challenge/:name` -> Returns all submissions for a specific challenge. Admin sees all attempts including flags, whereas contestants just see the successful attempts without flag.

-  `/api/info/submissions/user/:id` -> Returns all submissions made by a specific user. Admin sees all attempts including flags, contestants see the successful ones without the flag.

- Cheating field in the submissions which the admin can use to filter cheated submissions on the frontend.
