### PR TITLE
Dockerize beast update

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -23,6 +23,22 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get install -y ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg lsb-release && \
+    install -m 0755 -d /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    chmod a+r /etc/apt/keyrings/docker.gpg && \
+    echo \
+      "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+      $(. /etc/os-release && echo $VERSION_CODENAME) stable" \
+      > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y \
+      docker-ce-cli \
+      docker-compose-plugin \
+      docker-buildx-plugin && \
+    apt-get clean
+
 COPY --from=builder /go/bin/beast /usr/local/bin/beast
 COPY setup.sh /usr/local/bin/setup.sh
 RUN chmod +x /usr/local/bin/setup.sh

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -32,10 +32,12 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
       > /etc/apt/sources.list.d/docker.list && \
     apt-get update && \
     apt-get install -y \
+      redis-tools \
+      postgresql-client \
       docker-ce-cli \
       docker-compose-plugin \
       docker-buildx-plugin && \
-    apt-get clean
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/bin/beast /usr/local/bin/beast
 

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -38,6 +38,11 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
     apt-get clean
 
 COPY --from=builder /go/bin/beast /usr/local/bin/beast
+
+COPY --from=builder /usr/bin/docker-enter /usr/local/bin/docker-enter
+COPY --from=builder /usr/bin/docker_enter /usr/local/bin/docker_enter
+COPY --from=builder /usr/bin/importenv /usr/local/bin/importenv
+
 COPY setup.sh /usr/local/bin/setup.sh
 RUN chmod +x /usr/local/bin/setup.sh
 

--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -20,12 +20,10 @@ RUN make build
 
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y ca-certificates \
+RUN apt-get update && apt-get install -y ca-certificates curl gnupg lsb-release \
     && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get update && \
-    apt-get install -y ca-certificates curl gnupg lsb-release && \
-    install -m 0755 -d /etc/apt/keyrings && \
+RUN install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
     chmod a+r /etc/apt/keyrings/docker.gpg && \
     echo \


### PR DESCRIPTION
Adds the docker client to the image, since redis checks and docker compose both depend on `exec` and beast, at the moment, does not use docker api packages that supports compose.

Long Term Fix: migrate the docker API to use the newer API packages.